### PR TITLE
fix: re-enable stale builds, upgrade to bookworm

### DIFF
--- a/.github/workflows/keepalive.yaml
+++ b/.github/workflows/keepalive.yaml
@@ -3,6 +3,7 @@ name: keepalive
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 permissions:
   actions: write
@@ -17,5 +18,5 @@ jobs:
       - name: Keepalive
         uses: gautamkrishnar/keepalive-workflow@v2
         with:
-          workflow_files: "release.yaml"
+          workflow_files: "release.yaml,keepalive.yaml"
           time_elapsed: "0"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
   build:
     # The binary needs to be built in the same Docker image used as base
     # in the final image in order to link the right dependencies.
-    container: debian:bullseye-slim
+    container: debian:bookworm-slim
     defaults:
       run:
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG TARGETPLATFORM
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
Builds have been stuck at v26.1.0 since Feb 11 due to GitHub disabling scheduled workflows after 60 days of inactivity.

**Changes:**
- Upgrade build container and Dockerfile from `debian:bullseye-slim` to `debian:bookworm-slim`
- Fix keepalive workflow to also keep itself alive (`workflow_files: release.yaml,keepalive.yaml`)
- Add `workflow_dispatch` trigger to keepalive for manual re-enable

Once merged, re-enable both workflows in Actions tab and trigger a manual build for v26.3.0.