### PR TITLE
feat: publish separate validator client image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
           # Configuration
           DEPENDENCIES="${{ fromJson('{ "linux/arm64": "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu" }')[matrix.variant] }}"
           NIMFLAGS_COMMON="-d:const_preset=gnosis -d:disableMarchNative --gcc.options.debug:'-g1' --clang.options.debug:'-gline-tables-only'"
-          BINARIES="nimbus_beacon_node"
+          BINARIES="nimbus_beacon_node nimbus_validator_client"
 
           # Install cross-compile dependencies
           [ -n "$DEPENDENCIES" ] && apt install -y $DEPENDENCIES
@@ -157,7 +157,7 @@ jobs:
         with:
           path: ./artifacts
 
-      - name: Docker meta
+      - name: Docker meta (beacon node)
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -168,11 +168,33 @@ jobs:
             type=semver,pattern=v{{major}},value=${{ env.VERSION }}
             type=raw,value=${{ env.VERSION }},enable=${{ github.event_name != 'schedule' }}
 
-      - name: Build and push
+      - name: Build and push beacon node image
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile
           platforms: linux/arm64/v8,linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Docker meta (validator client)
+        id: meta-vc
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/gnosis-nimbus-validator-client
+          tags: |
+            type=semver,pattern=v{{version}},value=${{ env.VERSION }}
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ env.VERSION }}
+            type=semver,pattern=v{{major}},value=${{ env.VERSION }}
+            type=raw,value=${{ env.VERSION }},enable=${{ github.event_name != 'schedule' }}
+
+      - name: Build and push validator client image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.validator
+          platforms: linux/arm64/v8,linux/amd64
+          push: true
+          tags: ${{ steps.meta-vc.outputs.tags }}
+          labels: ${{ steps.meta-vc.outputs.labels }}

--- a/Dockerfile.validator
+++ b/Dockerfile.validator
@@ -1,0 +1,18 @@
+FROM debian:bookworm-slim
+
+ARG TARGETPLATFORM
+SHELL ["/bin/bash", "-c"]
+
+# Hack because we can't do substitutions in ARG / COPY
+COPY --chown=1000:1000 ./artifacts/ /tmp
+RUN addgroup --gid 1000 user \
+  && adduser --disabled-password --gecos '' --uid 1000 --gid 1000 user \
+  && cp /tmp/${TARGETPLATFORM//\//-}/nimbus_validator_client /home/user/nimbus_validator_client \
+  && chmod +x /home/user/nimbus_validator_client \
+  && rm -r /tmp/*
+
+USER user
+STOPSIGNAL SIGINT
+
+WORKDIR /home/user
+ENTRYPOINT ["/home/user/nimbus_validator_client"]


### PR DESCRIPTION
Closes #1.

Builds `nimbus_validator_client` alongside the beacon node and publishes it at `ghcr.io/<owner>/gnosis-nimbus-validator-client`, matching the upstream `statusim/nimbus-validator-client` split that dappnode and others already consume.

Tested locally on a 60-validator gnosis-preset devnet (Electra at genesis, geth as EL): both images boot, VC loads keys and publishes attestations + sync committee contributions, BN receives them, blocks are proposed and executed end-to-end through epoch 1.

## For dappnode

Once this merges, the two images are:

- `ghcr.io/gnosischain/gnosis-nimbus-eth2:<version>` — beacon node only
- `ghcr.io/gnosischain/gnosis-nimbus-validator-client:<version>` — validator client only

Same tag scheme as today (`v<X.Y.Z>`, `v<X.Y>`, `v<X>`), released in lockstep on the hourly release workflow.

Run the beacon node pointing at your EL, exposing REST for the VC:

```
docker run -d --name gnosis-bn \
  -v $GNOSIS_BN_DATA:/data \
  -v $JWT_FILE:/jwt.hex:ro \
  -p 9000:9000/tcp -p 9000:9000/udp \
  -p 5052:5052 \
  ghcr.io/gnosischain/gnosis-nimbus-eth2:<version> \
    --network=gnosis \
    --data-dir=/data \
    --el=http://<el-host>:8551 --jwt-secret=/jwt.hex \
    --rest --rest-address=0.0.0.0 --rest-port=5052
```

Run the validator client pointing at the beacon node's REST:

```
docker run -d --name gnosis-vc \
  -v $GNOSIS_VC_DATA:/data \
  -v $VALIDATORS_DIR:/validators \
  -v $SECRETS_DIR:/secrets \
  ghcr.io/gnosischain/gnosis-nimbus-validator-client:<version> \
    --data-dir=/data \
    --validators-dir=/validators \
    --secrets-dir=/secrets \
    --beacon-node=http://<bn-host>:5052
```

Notes:
- Both containers run as uid 1000, same as the existing image. Mounted data dirs need to be writable by 1000:1000, and `secrets/*` files need mode 0600.
- `--fee-recipient` / `--graffiti` belong on the VC, not the BN, once validators are split out. Everything else is the same as the upstream nimbus VC docs.